### PR TITLE
Fix attribute name (renamed attributeType to olcAttributeTypes)

### DIFF
--- a/schema/openldap/eduperson.ldif
+++ b/schema/openldap/eduperson.ldif
@@ -64,7 +64,7 @@ olcAttributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.6
 #
 ################################################################################
 #
-attributeType: ( 1.3.6.1.4.1.5923.1.1.1.12
+olcAttributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.12
     NAME 'eduPersonPrincipalNamePrior'
     DESC 'eduPerson per Internet2 and EDUCAUSE'
     EQUALITY caseIgnoreMatch


### PR DESCRIPTION
Attempting to add the schema with `ldapadd`  on OpenLDAP 2.4 fails with
```
ldap_add: Undefined attribute type (17)
        additional info: attributeType: attribute type undefined
```
Renaming the attribute in question to its OLC counterpart should fix that.