### PR TITLE
fixing a presumed typo on openLDAP schema file

### DIFF
--- a/schema/openldap/eduperson.ldif
+++ b/schema/openldap/eduperson.ldif
@@ -64,7 +64,7 @@ olcAttributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.6
 #
 ################################################################################
 #
-attributeType: ( 1.3.6.1.4.1.5923.1.1.1.12
+olcAttributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.12
     NAME 'eduPersonPrincipalNamePrior'
     DESC 'eduPerson per Internet2 and EDUCAUSE'
     EQUALITY caseIgnoreMatch


### PR DESCRIPTION
The ldif as downloaded from REFEDS/eduperson fails to import into OpenLDAP without this modification/fix via "ldapadd".