### PR TITLE
Edu person display pronouns

### DIFF
--- a/schema/openldap/eduperson.ldif
+++ b/schema/openldap/eduperson.ldif
@@ -155,6 +155,6 @@ olcObjectClasses: ( 1.3.6.1.4.1.5923.1.1.2
           eduPersonPrincipalName $ eduPersonPrincipalNamePrior $ eduPersonEntitlement $
           eduPersonPrimaryOrgUnitDN $ eduPersonScopedAffiliation $
           eduPersonTargetedID $ eduPersonAssurance $
-          eduPersonUniqueId $ eduPersonOrcid ) )
+          eduPersonUniqueId $ eduPersonOrcidi $ eduPersonDisplayPronouns ) )
 #
 ################################################################################

--- a/schema/openldap/eduperson.ldif
+++ b/schema/openldap/eduperson.ldif
@@ -148,7 +148,7 @@ olcAttributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.18
 #
 olcObjectClasses: ( 1.3.6.1.4.1.5923.1.1.2
     NAME 'eduPerson'
-    DESC 'eduPerson per Internet2 and EDUCAUSE'
+    DESC 'eduPerson (202208) - v4.4.0 - REFEDS Schema Board'
     AUXILIARY
     MAY ( eduPersonAffiliation $ eduPersonNickname $ eduPersonOrgDN $
           eduPersonOrgUnitDN $ eduPersonPrimaryAffiliation $

--- a/schema/openldap/eduperson.ldif
+++ b/schema/openldap/eduperson.ldif
@@ -1,4 +1,7 @@
-# eduPerson (201602)
+# REFEDS Schema Board
+#
+# eduPerson (202208) - v4.4.0
+#
 # $Customized for OpenLDAP$
 ################################################################################
 #


### PR DESCRIPTION
Reviewed the schema file, only one issue identified - eduPersonDisplayPronouns was missing from the eduPerson ObjectClass.

Updated the title of the schema file and description on the eduPerson ObjectClass to be the version and REFEDs Schema Board.

Many attributes have a description of "Attr-name per Internet2 and EDUCAUSE" should we update these to refer to the REFEDs Schema Board?